### PR TITLE
Add scoring and game over

### DIFF
--- a/game.html
+++ b/game.html
@@ -145,6 +145,7 @@
     function drawScore() {
       ctx.fillStyle = "white";
       ctx.font = "20px Arial";
+      ctx.textAlign = "left";
       ctx.fillText("Score: " + score, 10, 20);
     }
 

--- a/game.html
+++ b/game.html
@@ -30,7 +30,9 @@
     const SHEET_OFFSET_X = 23;
     const SHEET_OFFSET_Y = 18;
     const ENEMY_OFFSET_Y = 16;
-
+    let score = 0;
+    let gameOver = false;
+    let animationId;
 
     const player = {
       x: 50,
@@ -135,6 +137,23 @@
 
     let enemies = [];
     let spawnTimer = 0;
+    function drawScore() {
+      ctx.fillStyle = "white";
+      ctx.font = "20px Arial";
+      ctx.fillText("Score: " + score, 10, 20);
+    }
+
+    function showGameOver() {
+      ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = "white";
+      ctx.font = "40px Arial";
+      ctx.textAlign = "center";
+      ctx.fillText("Game Over", canvas.width / 2, canvas.height / 2);
+      ctx.font = "20px Arial";
+      ctx.fillText("Score: " + score, canvas.width / 2, canvas.height / 2 + 40);
+    }
+
 
     function gameLoop() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -151,16 +170,24 @@
       player.update();
       enemies.forEach(e => e.update());
 
-      enemies.forEach(e => {
-        if (
-          player.attacking &&
-          e.state === "walk" &&
-          Math.abs(player.x - e.x) < FRAME_WIDTH &&
-          Math.abs(player.y - e.y) < FRAME_HEIGHT
-        ) {
-          e.state = "hit";
-        }
-      });
+        enemies.forEach(e => {
+          if (
+            player.attacking &&
+            e.state === "walk" &&
+            Math.abs(player.x - e.x) < FRAME_WIDTH &&
+            Math.abs(player.y - e.y) < FRAME_HEIGHT
+          ) {
+            e.state = "hit";
+            score += 1;
+          } else if (
+            !player.attacking &&
+            e.state === "walk" &&
+            Math.abs(player.x - e.x) < FRAME_WIDTH &&
+            Math.abs(player.y - e.y) < FRAME_HEIGHT
+          ) {
+            gameOver = true;
+          }
+        });
 
       spawnTimer++;
       if (spawnTimer > 120) {
@@ -171,10 +198,16 @@
       player.draw();
       enemies.forEach(e => e.draw());
 
-      enemies = enemies.filter(e => e.state !== "dead");
+        enemies = enemies.filter(e => e.state !== "dead");
 
-      requestAnimationFrame(gameLoop);
-    }
+        drawScore();
+
+        if (!gameOver) {
+          animationId = requestAnimationFrame(gameLoop);
+        } else {
+          showGameOver();
+        }
+      }
 
     sprite.onload = () => {
       gameLoop();

--- a/game.html
+++ b/game.html
@@ -11,13 +11,18 @@
       margin: 0 auto;
       background-color: #111;
     }
+    body {
+      position: relative;
+    }
   </style>
 </head>
 <body>
   <canvas id="gameCanvas" width="640" height="360"></canvas>
+  <button id="resetBtn" style="display:none;position:absolute;left:50%;top:60%;transform:translate(-50%, -50%);padding:10px 20px;font-size:20px;">Restart</button>
   <script>
     const canvas = document.getElementById("gameCanvas");
     const ctx = canvas.getContext("2d");
+    const resetBtn = document.getElementById("resetBtn");
 
     const gravity = 0.5;
     const groundY = 300;
@@ -143,16 +148,33 @@
       ctx.fillText("Score: " + score, 10, 20);
     }
 
-    function showGameOver() {
-      ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-      ctx.fillStyle = "white";
-      ctx.font = "40px Arial";
-      ctx.textAlign = "center";
-      ctx.fillText("Game Over", canvas.width / 2, canvas.height / 2);
-      ctx.font = "20px Arial";
-      ctx.fillText("Score: " + score, canvas.width / 2, canvas.height / 2 + 40);
-    }
+  function showGameOver() {
+    ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "white";
+    ctx.font = "40px Arial";
+    ctx.textAlign = "center";
+    ctx.fillText("Game Over", canvas.width / 2, canvas.height / 2);
+    ctx.font = "20px Arial";
+    ctx.fillText("Score: " + score, canvas.width / 2, canvas.height / 2 + 40);
+    resetBtn.style.display = "block";
+  }
+
+  function resetGame() {
+    score = 0;
+    gameOver = false;
+    enemies = [];
+    spawnTimer = 0;
+    player.x = 50;
+    player.y = groundY;
+    player.vx = 0;
+    player.vy = 0;
+    player.jumping = false;
+    player.attacking = false;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    resetBtn.style.display = "none";
+    gameLoop();
+  }
 
 
     function gameLoop() {
@@ -208,6 +230,8 @@
           showGameOver();
         }
       }
+
+    resetBtn.addEventListener("click", resetGame);
 
     sprite.onload = () => {
       gameLoop();


### PR DESCRIPTION
## Summary
- implement score tracking
- stop the game and display overlay when hit by enemy

## Testing
- `node - <<'EOF'
const fs=require('fs');
const data=fs.readFileSync('game.html','utf8');
const match=data.match(/<script>([\s\S]*?)<\/script>/);
if(match){
  try{ new Function(match[1]); console.log('JS syntax OK'); } catch(e){ console.error('JS syntax error:', e.message); }}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68652a4f1ea88323aa1d8a0966d2c075