### PR TITLE
Adjust first row sprite offset

### DIFF
--- a/game.html
+++ b/game.html
@@ -137,7 +137,7 @@
           this.frame = 3;
         }
           if (!this.invincible || Math.floor(frameCount / 5) % 2 === 0) {
-            const yOffset = frameY === 0 ? 4 : 0;
+            const yOffset = frameY === 0 ? 6 : 0;
             ctx.drawImage(
               sprite,
               SHEET_OFFSET_X + Math.floor(this.frame) * FRAME_WIDTH,

--- a/game.html
+++ b/game.html
@@ -137,17 +137,18 @@
           this.frame = 3;
         }
           if (!this.invincible || Math.floor(frameCount / 5) % 2 === 0) {
-          ctx.drawImage(
-            sprite,
-            SHEET_OFFSET_X + Math.floor(this.frame) * FRAME_WIDTH,
-            SHEET_OFFSET_Y + frameY * FRAME_HEIGHT,
-            FRAME_WIDTH,
-            FRAME_HEIGHT,
-            this.x - SPRITE_PADDING,
-            this.y - SPRITE_PADDING,
-            FRAME_WIDTH,
-            FRAME_HEIGHT
-          );
+            const yOffset = frameY === 0 ? 4 : 0;
+            ctx.drawImage(
+              sprite,
+              SHEET_OFFSET_X + Math.floor(this.frame) * FRAME_WIDTH,
+              SHEET_OFFSET_Y + frameY * FRAME_HEIGHT,
+              FRAME_WIDTH,
+              FRAME_HEIGHT,
+              this.x - SPRITE_PADDING,
+              this.y - SPRITE_PADDING + yOffset,
+              FRAME_WIDTH,
+              FRAME_HEIGHT
+            );
           }
           if (DEBUG) {
             ctx.strokeStyle = "lime";


### PR DESCRIPTION
## Summary
- fix first row sprite vertical offset so player isn't floating

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686582de4f6483238d29bd4989896207