### PR TITLE
Update score and health text color

### DIFF
--- a/game.html
+++ b/game.html
@@ -280,14 +280,14 @@
       return scores.length < MAX_HIGH_SCORES || s > scores[scores.length - 1].score;
     }
     function drawScore() {
-      ctx.fillStyle = "white";
+      ctx.fillStyle = "black";
       ctx.font = "20px Arial";
       ctx.textAlign = "left";
       ctx.fillText("Score: " + score, 10, 20);
     }
 
     function drawHealth() {
-      ctx.fillStyle = "white";
+      ctx.fillStyle = "black";
       ctx.font = "20px Arial";
       ctx.textAlign = "right";
       ctx.fillText("Health: " + health, canvas.width - 10, 20);


### PR DESCRIPTION
## Summary
- draw score and health text in black instead of white

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686585400d348323bb502c6be4287cfd