### PR TITLE
Implement pause with P key

### DIFF
--- a/game.html
+++ b/game.html
@@ -27,6 +27,7 @@
       <button id="saveScoreBtn" style="padding:5px;">Save Score</button>
     </div>
   </div>
+  <div id="pauseOverlay" style="display:none;position:absolute;left:50%;top:50%;transform:translate(-50%, -50%);font-size:40px;color:white;text-align:center;">Paused</div>
   <script>
     const canvas = document.getElementById("gameCanvas");
     const ctx = canvas.getContext("2d");
@@ -36,6 +37,7 @@
     const nameEntry = document.getElementById("nameEntry");
     const nameInput = document.getElementById("nameInput");
     const saveScoreBtn = document.getElementById("saveScoreBtn");
+    const pauseOverlay = document.getElementById("pauseOverlay");
     const MAX_HIGH_SCORES = 5;
 
     const gravity = 0.5;
@@ -65,6 +67,7 @@
     let health = 3;
     let gameOver = false;
     let animationId;
+    let paused = false;
 
     let frameCount = 0;
     let gameStartTime = Date.now();
@@ -269,7 +272,22 @@
     }
 
     const keys = {};
-    document.addEventListener("keydown", e => keys[e.key] = true);
+    document.addEventListener("keydown", e => {
+      if (e.key.toLowerCase() === "p") {
+        if (!gameOver) {
+          paused = !paused;
+          if (paused) {
+            cancelAnimationFrame(animationId);
+            pauseOverlay.style.display = "block";
+          } else {
+            pauseOverlay.style.display = "none";
+            animationId = requestAnimationFrame(gameLoop);
+          }
+        }
+      } else {
+        keys[e.key] = true;
+      }
+    });
     document.addEventListener("keyup", e => {
       keys[e.key] = false;
       if (e.key === " ") player.attacking = false;


### PR DESCRIPTION
## Summary
- add a pause overlay element
- track paused state and toggle with the `P` key
- hide/show the overlay and stop/resume the animation loop accordingly

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866e5d8a8288323a720c7afb039591b