### PR TITLE
Lower soundtrack octave

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -68,16 +68,16 @@ let paused = false;
 let audioCtx;
 let musicInterval;
 let musicVolume = 0.05;
-// 8-note chiptune loop: C4 D4 E4 F4 G4 A4 G4 E4
+// 8-note chiptune loop: C3 D3 E3 F3 G3 A3 G3 E3
 const musicNotes = [
-  261.63, // C4
-  293.66, // D4
-  329.63, // E4
-  349.23, // F4
-  392.0,  // G4
-  440.0,  // A4
-  392.0,  // G4
-  329.63 // E4
+  130.81, // C3
+  146.83, // D3
+  164.82, // E3
+  174.62, // F3
+  196.0,  // G3
+  220.0,  // A3
+  196.0,  // G3
+  164.82 // E3
 ];
 
 function playNote(freq, duration = 0.3) {


### PR DESCRIPTION
## Summary
- lower frequencies of background music to shift soundtrack down one octave

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68693a19682c8323a1dd8adcc7dc0710