### PR TITLE
Stop background music when game ends

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -561,6 +561,7 @@ function drawGround() {
 }
 
 function showGameOver() {
+  stopBackgroundMusic();
   playDeathSound();
   ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
   ctx.fillRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
## Summary
- prevent background music from continuing after player death

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68694d37f4a48323a8c1fbcb180f6f7e