### PR TITLE
Auto-scrolling world with health penalty on left edge

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -28,12 +28,13 @@ const gravity = 0.5;
 const groundY = 250;
 const CLOUD_SPEED = 0.2;
 let worldSpeed = 0;
-const BASE_WORLD_SPEED = -0.2;
-const WORLD_SPEED_INCREMENT = ENEMY_SPEED_INCREMENT;
-const PLAYER_SPEED = 4;
 
 const BASE_ENEMY_SPEED = -1.5;
 const ENEMY_SPEED_INCREMENT = 8 / 60;
+
+const BASE_WORLD_SPEED = -0.2;
+const WORLD_SPEED_INCREMENT = ENEMY_SPEED_INCREMENT;
+const PLAYER_SPEED = 4;
 const BASE_SPAWN_INTERVAL = 120;
 
 const sprite = new Image();
@@ -735,7 +736,6 @@ function gameLoop() {
   });
 
   spawnTimer++;
-  const elapsedSeconds = (Date.now() - gameStartTime - totalPausedTime) / 1000;
   const spawnInterval = BASE_SPAWN_INTERVAL / (1 + ENEMY_SPEED_INCREMENT * elapsedSeconds);
   if (spawnTimer > spawnInterval) {
     const randomCharacter = characters[Math.floor(Math.random() * characters.length)];

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -28,6 +28,8 @@ const gravity = 0.5;
 const groundY = 250;
 const CLOUD_SPEED = 0.2;
 let worldSpeed = 0;
+const BASE_WORLD_SPEED = -0.2;
+const WORLD_SPEED_INCREMENT = ENEMY_SPEED_INCREMENT;
 const PLAYER_SPEED = 4;
 
 const BASE_ENEMY_SPEED = -1.5;
@@ -236,6 +238,7 @@ const player = {
   blockCooldown: 0,
   invincible: false,
   invincibility: 0,
+  touchingLeft: false,
   attack() {
     if (!this.attacking && this.cooldown <= 0) {
       this.attacking = true;
@@ -296,8 +299,15 @@ const player = {
     this.x += this.vx + worldSpeed;
     if (this.x < 0) {
       this.x = 0;
-    } else if (this.x + this.width > canvas.width) {
-      this.x = canvas.width - this.width;
+      if (!this.touchingLeft) {
+        this.touchingLeft = true;
+        this.hit();
+      }
+    } else {
+      this.touchingLeft = false;
+      if (this.x + this.width > canvas.width) {
+        this.x = canvas.width - this.width;
+      }
     }
   },
   draw() {
@@ -608,6 +618,7 @@ function initGame() {
   player.attacking = false;
   player.attackTimer = 0;
   player.cooldown = 0;
+  player.touchingLeft = false;
   initTerrain();
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   resetBtn.style.display = "none";
@@ -661,9 +672,10 @@ function gameLoop() {
   updateClouds();
   drawClouds();
 
-  worldSpeed = 0;
+  const elapsedSeconds = (Date.now() - gameStartTime - totalPausedTime) / 1000;
+  worldSpeed = BASE_WORLD_SPEED * (1 + WORLD_SPEED_INCREMENT * elapsedSeconds);
   if (player.x > canvas.width * 0.6 && player.vx > 0) {
-    worldSpeed = -player.vx;
+    worldSpeed -= player.vx;
   }
 
   if (keys["ArrowLeft"]) {


### PR DESCRIPTION
## Summary
- add world auto-scroll that accelerates over time
- damage player when touching the left screen edge

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6869652abf9c8323aa788aebd5c123e1