### PR TITLE
Adjust world speed trigger threshold

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -675,7 +675,7 @@ function gameLoop() {
 
   const elapsedSeconds = (Date.now() - gameStartTime - totalPausedTime) / 1000;
   worldSpeed = BASE_WORLD_SPEED * (1 + WORLD_SPEED_INCREMENT * elapsedSeconds);
-  if (player.x > canvas.width * 0.6 && player.vx > 0) {
+  if (player.x > canvas.width * 0.5 && player.vx > 0) {
     worldSpeed -= player.vx;
   }
 


### PR DESCRIPTION
## Summary
- reduce the screen position threshold that speeds up the world

## Testing
- `node -v`
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_68696c27a65c8323808e944c6d6dd9b9