### PR TITLE
Add additional unit tests

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+function loadGameDom() {
+  const html = fs.readFileSync(path.join(__dirname, '../game.html'), 'utf8');
+  const dom = new JSDOM(html, {
+    url: 'http://localhost',
+    runScripts: 'dangerously',
+    pretendToBeVisual: true,
+  });
+
+  dom.window.HTMLCanvasElement.prototype.getContext = () => ({
+    fillRect: () => {},
+    clearRect: () => {},
+    drawImage: () => {},
+    beginPath: () => {},
+    arc: () => {},
+    fill: () => {},
+  });
+
+  dom.window.Image = class {
+    constructor() {
+      this.onload = null;
+    }
+    set src(_v) {
+      if (typeof this.onload === 'function') {
+        this.onload();
+      }
+    }
+  };
+
+  dom.window.AudioContext = class {
+    constructor() {
+      this.currentTime = 0;
+      this.state = 'running';
+      this.destination = {};
+    }
+    createOscillator() {
+      return {
+        type: '',
+        frequency: { setValueAtTime() {} },
+        connect() {},
+        start() {},
+        stop() {},
+      };
+    }
+    createGain() {
+      return {
+        gain: { setValueAtTime() {} },
+        connect() {},
+      };
+    }
+    resume() {}
+  };
+
+  // Load the game script manually so tests can access globals
+  const scriptText = fs.readFileSync(
+    path.join(__dirname, '../assets/js/game.js'),
+    'utf8'
+  );
+  dom.window.eval(scriptText);
+
+  return new Promise((resolve, reject) => {
+    dom.window.addEventListener('error', (e) => reject(e.error || e.message));
+    setTimeout(() => resolve(dom), 50);
+  });
+}
+
+module.exports = { loadGameDom };

--- a/test/logic.test.js
+++ b/test/logic.test.js
@@ -1,0 +1,57 @@
+const { loadGameDom } = require('./helpers');
+
+async function setup() {
+  const dom = await loadGameDom();
+  dom.window.localStorage.clear();
+  return dom;
+}
+
+test('rectsOverlap detects collisions correctly', async () => {
+  const dom = await setup();
+  const { rectsOverlap } = dom.window;
+  expect(rectsOverlap(
+    { x: 0, y: 0, width: 10, height: 10 },
+    { x: 5, y: 5, width: 10, height: 10 }
+  )).toBe(true);
+  expect(rectsOverlap(
+    { x: 0, y: 0, width: 10, height: 10 },
+    { x: 20, y: 20, width: 10, height: 10 }
+  )).toBe(false);
+});
+
+test('collisionSide identifies side of collision', async () => {
+  const dom = await setup();
+  const { collisionSide } = dom.window;
+  const a = { x: 10, y: 10, width: 10, height: 10 };
+  const bLeft = { x: 5, y: 10, width: 10, height: 10 };
+  const bTop = { x: 10, y: 5, width: 10, height: 10 };
+  expect(collisionSide(a, bLeft)).toBe('right');
+  expect(collisionSide(a, bTop)).toBe('bottom');
+});
+
+test('qualifiesForHighScore evaluates scores', async () => {
+  const dom = await setup();
+  const { qualifiesForHighScore } = dom.window;
+  dom.window.localStorage.setItem('highScores', JSON.stringify([
+    { name: 'A', score: 10 },
+    { name: 'B', score: 9 },
+    { name: 'C', score: 8 },
+    { name: 'D', score: 7 },
+    { name: 'E', score: 6 },
+  ]));
+  expect(qualifiesForHighScore(6)).toBe(false);
+  expect(qualifiesForHighScore(7)).toBe(true);
+
+  dom.window.localStorage.setItem('highScores', JSON.stringify([
+    { name: 'A', score: 10 },
+  ]));
+  expect(qualifiesForHighScore(1)).toBe(true);
+});
+
+test('saveHighScores and loadHighScores round trip', async () => {
+  const dom = await setup();
+  const { saveHighScores, loadHighScores } = dom.window;
+  const arr = [{ name: 'Foo', score: 12 }];
+  saveHighScores(arr);
+  expect(loadHighScores()).toEqual(arr);
+});


### PR DESCRIPTION
## Summary
- add helper for JSDOM setup that loads the game script
- add new test suite covering collision and high score logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697974f02483239f54abac60a7a46f