### PR TITLE
Add snare percussion to music

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -121,6 +121,29 @@ function playKick(volume = musicVolume) {
   osc.stop(audioCtx.currentTime + 0.11);
 }
 
+function playSnare(volume = musicVolume) {
+  if (!audioCtx) return;
+  const bufferSize = audioCtx.sampleRate * 0.2;
+  const buffer = audioCtx.createBuffer(1, bufferSize, audioCtx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < bufferSize; i++) {
+    data[i] = Math.random() * 2 - 1;
+  }
+  const noise = audioCtx.createBufferSource();
+  noise.buffer = buffer;
+  const filter = audioCtx.createBiquadFilter();
+  filter.type = "highpass";
+  filter.frequency.setValueAtTime(800, audioCtx.currentTime);
+  const gain = audioCtx.createGain();
+  gain.gain.setValueAtTime(volume * 5, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.2);
+  noise.connect(filter);
+  filter.connect(gain);
+  gain.connect(audioCtx.destination);
+  noise.start();
+  noise.stop(audioCtx.currentTime + 0.2);
+}
+
 function startBackgroundMusic() {
   if (!audioCtx) {
     audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -135,6 +158,8 @@ function startBackgroundMusic() {
     playNote(musicNotes[idx % musicNotes.length], 0.3, musicVolume);
     if (beat % 4 === 0) {
       playKick(musicVolume);
+    } else if (beat % 4 === 2) {
+      playSnare(musicVolume);
     }
     idx++;
     beat++;

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -38,6 +38,7 @@ test('game.js runs without errors', () => {
       this.currentTime = 0;
       this.state = 'running';
       this.destination = {};
+      this.sampleRate = 44100;
     }
     createOscillator() {
       return {
@@ -51,6 +52,28 @@ test('game.js runs without errors', () => {
     createGain() {
       return {
         gain: { setValueAtTime() {} },
+        connect() {},
+      };
+    }
+    createBuffer() {
+      return {
+        getChannelData() {
+          return new Float32Array(0);
+        },
+      };
+    }
+    createBufferSource() {
+      return {
+        buffer: null,
+        connect() {},
+        start() {},
+        stop() {},
+      };
+    }
+    createBiquadFilter() {
+      return {
+        type: '',
+        frequency: { setValueAtTime() {} },
         connect() {},
       };
     }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -35,6 +35,7 @@ function loadGameDom() {
       this.currentTime = 0;
       this.state = 'running';
       this.destination = {};
+      this.sampleRate = 44100;
     }
     createOscillator() {
       return {
@@ -48,6 +49,28 @@ function loadGameDom() {
     createGain() {
       return {
         gain: { setValueAtTime() {} },
+        connect() {},
+      };
+    }
+    createBuffer() {
+      return {
+        getChannelData() {
+          return new Float32Array(0);
+        },
+      };
+    }
+    createBufferSource() {
+      return {
+        buffer: null,
+        connect() {},
+        start() {},
+        stop() {},
+      };
+    }
+    createBiquadFilter() {
+      return {
+        type: '',
+        frequency: { setValueAtTime() {} },
         connect() {},
       };
     }


### PR DESCRIPTION
## Summary
- add a playSnare function that generates noise for a snare sound
- trigger snare hits on alternating beats in the background music
- extend test AudioContext stubs to cover noise-related methods

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697f34781c83239e0a5459b5dd03c8