### PR TITLE
Fix enemy speed reset

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -694,6 +694,8 @@
   }
 
   function resetGame() {
+    worldSpeed = 0;
+    gameStartTime = Date.now();
     resetBtn.style.display = "none";
     scoreContainer.style.display = "none";
     nameEntry.style.display = "none";
@@ -709,6 +711,7 @@
     spawnTimer = 0;
     enemyKillCount = 0;
     healthPacks = [];
+    worldSpeed = 0;
     gameStartTime = Date.now();
     totalPausedTime = 0;
     player.x = 50;
@@ -740,7 +743,9 @@
   function startGame(character) {
     cancelAnimationFrame(animationId);
     selectedCharacter = character;
-    sprite.src = `assets/images/sprite-${character.toLowerCase()}.png`;
+    const spritePath = `assets/images/sprite-${character.toLowerCase()}.png`;
+    const alreadyLoaded = sprite.complete && sprite.src.endsWith(spritePath);
+    sprite.src = spritePath;
     characterSelectionDiv.style.display = "none";
     canvas.style.display = "block";
     volumeControl.style.display = "flex";
@@ -748,18 +753,32 @@
     // Reset timing so regular play always begins at base speed
     gameStartTime = Date.now();
     worldSpeed = 0;
+    // Ensure player velocity is cleared when starting real play
+    player.vx = 0;
+    player.vy = 0;
     startBackgroundMusic();
+    if (alreadyLoaded) {
+      initGame();
+    }
   }
 
   function startDemo() {
     const randomCharacter = characters[Math.floor(Math.random() * characters.length)];
     selectedCharacter = randomCharacter;
-    sprite.src = `assets/images/sprite-${randomCharacter.toLowerCase()}.png`;
+    const spritePath = `assets/images/sprite-${randomCharacter.toLowerCase()}.png`;
+    const alreadyLoaded = sprite.complete && sprite.src.endsWith(spritePath);
+    sprite.src = spritePath;
     autoplaying = true;
     stopBackgroundMusic();
     // Reset time tracking so world speed starts from the baseline
     gameStartTime = Date.now();
     worldSpeed = 0;
+    // Ensure player velocity resets between demo runs
+    player.vx = 0;
+    player.vy = 0;
+    if (alreadyLoaded) {
+      initGame();
+    }
   }
 
 


### PR DESCRIPTION
## Summary
- ensure game state resets when starting a game even if sprite is already loaded
- clear player velocity when starting demo or normal play

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a97a1aa08323b3ed5177b3f6d83f