### PR TITLE
Fix stuck input after reset

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -868,6 +868,8 @@
     worldSpeed = 0;
     gameStartTime = Date.now();
     restartButtonRect = null;
+    awaitingNameEntry = false;
+    enteredName = "";
     stopBackgroundMusic();
     showCharacterSelection();
   }


### PR DESCRIPTION
## Summary
- clear name entry state when resetting the game

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686aa0b8a4608323a235d8e494665982