### PR TITLE
Fix leftover key states on restart

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -603,6 +603,12 @@
   }
 
   const keys = {};
+
+  function resetKeys() {
+    for (const k in keys) {
+      keys[k] = false;
+    }
+  }
   document.addEventListener("keydown", e => {
     if (awaitingNameEntry) {
       if (e.key === "Backspace") {
@@ -921,6 +927,7 @@
     sliders.sfx.value = sfxVolume;
     sliders.music.value = musicVolume;
     autoplaying = false;
+    resetKeys();
     // Reset timing so regular play always begins at base speed
     gameStartTime = Date.now();
     worldSpeed = 0;
@@ -941,6 +948,7 @@
     sprite.src = spritePath;
     autoplaying = true;
     showVolume = false;
+    resetKeys();
     stopBackgroundMusic();
     // Reset time tracking so world speed starts from the baseline
     gameStartTime = Date.now();


### PR DESCRIPTION
## Summary
- reset the keys array whenever starting a new game or demo

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686aa400bc588323b4bfa5cf00c02654