### PR TITLE
Fix lethal hit invincibility

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -491,13 +491,16 @@
     },
     hit() {
       if (!this.invincible && !this.blocking) {
-        this.invincible = true;
-        this.invincibility = 60;
+        health--;
+        const willDie = health < 1;
+        if (!willDie) {
+          this.invincible = true;
+          this.invincibility = 60;
+        }
         this.vy = -8;
         this.jumping = true;
-        health--;
         playDamageSound();
-        if (health < 1) {
+        if (willDie) {
           gameOver = true;
         }
       }


### PR DESCRIPTION
## Summary
- avoid granting invincibility when the hit would kill the player

## Testing
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_686b5b9f55608323822e61fe54189ea2