### PR TITLE
Fix health not going negative

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -491,7 +491,7 @@
     },
     hit() {
       if (!this.invincible && !this.blocking) {
-        health--;
+        health = Math.max(0, health - 1);
         const willDie = health < 1;
         if (!willDie) {
           this.invincible = true;
@@ -1301,6 +1301,10 @@
   Game.qualifiesForHighScore = qualifiesForHighScore;
   Game.loadHighScores = loadHighScores;
   Game.saveHighScores = saveHighScores;
+  // Testing helpers
+  Game._getHealthForTest = () => health;
+  Game._setHealthForTest = (v) => { health = v; };
+  Game._hitPlayerForTest = () => player.hit();
 
   window.Game = Game;
 

--- a/test/health.test.js
+++ b/test/health.test.js
@@ -1,0 +1,11 @@
+const { loadGameDom } = require('./helpers');
+
+test('player health never goes negative', async () => {
+  const dom = await loadGameDom();
+  const Game = dom.window.Game;
+  Game._setHealthForTest(1);
+  Game._hitPlayerForTest();
+  expect(Game._getHealthForTest()).toBe(0);
+  Game._hitPlayerForTest();
+  expect(Game._getHealthForTest()).toBe(0);
+});


### PR DESCRIPTION
## Summary
- clamp health at zero when player takes damage
- expose test helpers to modify and check health
- add regression test to ensure health never goes negative

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686b5da48c6083239b6039948e6ff818