### PR TITLE
Display stacked health in 2 player mode

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -757,12 +757,10 @@
   function drawHealth() {
     ctx.fillStyle = "black";
     if (twoPlayerMode) {
-      drawSpriteText(
-        `P1 ${health} P2 ${health2}`,
-        canvas.width - 10,
-        10,
-        "right"
-      );
+      const x = canvas.width - 10;
+      const lineHeight = DRAW_CHAR_HEIGHT + 4;
+      drawSpriteText(`P1 ${health}`, x, 10, "right");
+      drawSpriteText(`P2 ${health2}`, x, 10 + lineHeight, "right");
     } else {
       drawSpriteText("HEALTH " + health, canvas.width - 10, 10, "right");
     }


### PR DESCRIPTION
## Summary
- place P1 and P2 health vertically when two-player mode is active

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b9c3802e08323a9dccdf6865537f8