### PR TITLE
Replace volume labels with sprite text

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -613,7 +613,13 @@
     ctx.fillStyle = "white";
     ctx.fillRect(handleX - 2, sliderY - 2, 4, SLIDER_HEIGHT + 4);
     ctx.fillStyle = "black";
-    ctx.fillText(label, slider.x + slider.width + 5, slider.y + SLIDER_HEIGHT);
+    drawSpriteText(
+      label,
+      slider.x + slider.width + 5,
+      slider.y + SLIDER_HEIGHT,
+      "left",
+      0.5
+    );
   }
 
   function drawVolumeSliders() {


### PR DESCRIPTION
## Summary
- use `drawSpriteText` in `drawSlider` so volume slider labels use the sprite letters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686bec91c9748323bae9451cee7f73ac