### PR TITLE
Fix bushes drawing over gaps

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -896,6 +896,11 @@
     ctx.globalAlpha = 0.5;
     ctx.fillStyle = "green";
     bushes.forEach(b => {
+      // skip drawing if the bush overlaps a gap
+      const gap = gaps.find(g =>
+        b.x + BUSH_WIDTH / 2 > g.x && b.x - BUSH_WIDTH / 2 < g.x + g.width
+      );
+      if (gap) return;
       const bx = b.x - BUSH_WIDTH / 2;
       const by = GROUND_SURFACE_Y - BUSH_HEIGHT;
       ctx.fillRect(bx, by, BUSH_WIDTH, BUSH_HEIGHT);


### PR DESCRIPTION
## Summary
- avoid drawing bushes if they overlap a terrain gap

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c9caf86a083238e134e7fe6d91e83