### PR TITLE
Fix ground seams from subpixel scrolling

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -944,10 +944,13 @@
   function drawGround() {
     ctx.fillStyle = "green";
     terrainBlocks.forEach(block => {
-      ctx.fillRect(block.x, block.y, TERRAIN_BLOCK_WIDTH, canvas.height - block.y);
+      const x = Math.round(block.x);
+      ctx.fillRect(x, block.y, TERRAIN_BLOCK_WIDTH, canvas.height - block.y);
     });
     gaps.forEach(gap => {
-      ctx.clearRect(gap.x, groundY, gap.width, canvas.height - groundY);
+      const x = Math.round(gap.x);
+      const width = Math.round(gap.width);
+      ctx.clearRect(x, groundY, width, canvas.height - groundY);
     });
   }
 


### PR DESCRIPTION
## Summary
- prevent gaps between ground blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ca33ebb348323abfe7328419fd5e5