### PR TITLE
Add cache-busting query parameters

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1066,11 +1066,11 @@
     selectedCharacter1 = character;
     selectedCharacter2 = character2;
     twoPlayerMode = twoPlayerSelected;
-    const spritePath = `assets/images/sprite-${character.toLowerCase()}.png`;
+    const spritePath = `assets/images/sprite-${character.toLowerCase()}.png?v=1.0`;
     const alreadyLoaded = sprite.complete && sprite.src.endsWith(spritePath);
     sprite.src = spritePath;
     if (twoPlayerMode) {
-      const spritePath2 = `assets/images/sprite-${character2.toLowerCase()}.png`;
+      const spritePath2 = `assets/images/sprite-${character2.toLowerCase()}.png?v=1.0`;
       sprite2.src = spritePath2;
     }
     characterSelectionVisible = false;
@@ -1099,7 +1099,7 @@
     if (!demoPreserve) {
       selectedCharacter1 = randomCharacter;
     }
-    const spritePath = `assets/images/sprite-${randomCharacter.toLowerCase()}.png`;
+    const spritePath = `assets/images/sprite-${randomCharacter.toLowerCase()}.png?v=1.0`;
     const alreadyLoaded = sprite.complete && sprite.src.endsWith(spritePath);
     sprite.src = spritePath;
     Game.autoplaying = true;
@@ -1552,7 +1552,7 @@
     const total = characters.length + 3;
     for (const char of characters) {
       const img = new Image();
-      img.src = `assets/images/sprite-${char.toLowerCase()}.png`;
+      img.src = `assets/images/sprite-${char.toLowerCase()}.png?v=1.0`;
       img.onload = () => {
         loaded++;
         if (loaded === total) {
@@ -1561,21 +1561,21 @@
       };
       spriteCache[char.toLowerCase()] = img;
     }
-    alphabetSprite.src = "assets/images/sprite-alphabet.png";
+    alphabetSprite.src = "assets/images/sprite-alphabet.png?v=1.0";
     alphabetSprite.onload = () => {
       loaded++;
       if (loaded === total) {
         showCharacterSelection(1);
       }
     };
-    numbersSprite.src = "assets/images/sprite-numbers.png";
+    numbersSprite.src = "assets/images/sprite-numbers.png?v=1.0";
     numbersSprite.onload = () => {
       loaded++;
       if (loaded === total) {
         showCharacterSelection(1);
       }
     };
-    heartSprite.src = "assets/images/sprite-heart.png";
+    heartSprite.src = "assets/images/sprite-heart.png?v=1.0";
     heartSprite.onload = () => {
       loaded++;
       if (loaded === total) {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Platform Game</title>
-  <link rel="stylesheet" href="assets/css/styles.css" />
+  <link rel="stylesheet" href="assets/css/styles.css?v=1.0" />
 </head>
 <body>
   <div id="instructions">
@@ -19,8 +19,8 @@
     </ul>
   </div>
   <canvas id="gameCanvas" width="640" height="360"></canvas>
-  <script src="assets/js/util.js"></script>
-  <script src="assets/js/audio.js"></script>
-  <script src="assets/js/game.js"></script>
+  <script src="assets/js/util.js?v=1.0"></script>
+  <script src="assets/js/audio.js?v=1.0"></script>
+  <script src="assets/js/game.js?v=1.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a version query string to CSS and JS paths
- append cache-busting query to sprite image references
- fix indentation for asset URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686cab19d9448323abb89b07b0015a67